### PR TITLE
Silence unused launcher response fields to remove build warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -503,8 +503,8 @@ impl Application for App {
                         }
                         pop_launcher::Response::DesktopEntry {
                             path,
-                            gpu_preference,
-                            action_name,
+                            gpu_preference: _,
+                            action_name: _,
                         } => {
                             // Launch the desktop file
                             if let Err(_e) = std::process::Command::new("gtk-launch")


### PR DESCRIPTION
### Motivation
- Remove two `unused variable` compiler warnings emitted during the build by the `pop_launcher::Response::DesktopEntry` match arm.

### Description
- Explicitly ignore `gpu_preference` and `action_name` by changing the pattern to `gpu_preference: _` and `action_name: _` in the `pop_launcher::Response::DesktopEntry` match, which silences the warnings without changing runtime behavior.

### Testing
- Attempted `cargo check --release` and `cargo check --release --locked --offline`; both checks could not complete in this environment due to fetching the git-based COSMIC dependencies (network fetch blocked / missing local git refs), so the patch was validated by local inspection and a successful compile in the original install transcript which showed only warnings prior to the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fa4a91f0c8326a648ba7d099b1b7a)